### PR TITLE
docs: add AUTHORS.md with all contributors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,30 @@
+# Authors
+
+Agent Orchestrator is built and maintained by contributors from the community. Thank you to everyone who has helped shape this project.
+
+## Core Team
+
+- **[suraj-markup](https://github.com/suraj-markup)**
+- **[AgentWrapper](https://github.com/AgentWrapper)**
+- **[ashish921998](https://github.com/ashish921998)**
+- **[illegalcall](https://github.com/illegalcall)**
+- **[harsh-batheja](https://github.com/harsh-batheja)**
+
+## Contributors
+
+| GitHub | Contributions |
+|--------|--------------|
+| [@gautamtayal1](https://github.com/gautamtayal1) | 29 |
+| [@harshitsinghbhandari](https://github.com/harshitsinghbhandari) | 25 |
+| [@ChiragArora31](https://github.com/ChiragArora31) | 6 |
+| [@Deepak7704](https://github.com/Deepak7704) | 5 |
+| [@ruskaruma](https://github.com/ruskaruma) | 5 |
+| [@wjayesh](https://github.com/wjayesh) | 4 |
+| [@sujayjayjay](https://github.com/sujayjayjay) | 2 |
+| [@andykamin3](https://github.com/andykamin3) | 1 |
+| [@sigvardt](https://github.com/sigvardt) | 1 |
+| [@kaavee315](https://github.com/kaavee315) | 1 |
+
+---
+
+Want to see your name here? Check out [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/README.md
+++ b/README.md
@@ -188,3 +188,7 @@ Contributions welcome. The plugin system makes it straightforward to add support
 ## License
 
 MIT
+
+---
+
+See [AUTHORS.md](AUTHORS.md) for the full list of contributors.


### PR DESCRIPTION
## Summary

- Adds `AUTHORS.md` listing all 15 contributors, organized into a core team (top 5 by contributions) and a contributors table with contribution counts
- Adds a link to `AUTHORS.md` in the README footer

Closes #4

## Test plan

- [ ] Verify `AUTHORS.md` exists and renders correctly on GitHub
- [ ] Verify the README footer link to `AUTHORS.md` works