### PR TITLE
feat: surface pending plan approval in the Respond column

### DIFF
--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -44,7 +44,7 @@ const zoneConfig: Record<
   respond: {
     label: "Respond",
     color: "var(--color-status-error)",
-    caption: "Human judgment needed",
+    caption: "Your input is needed",
   },
   review: {
     label: "Review",
@@ -292,7 +292,11 @@ function SessionStateChip({
   if (level === "merge" && session.pr && isPRMergeReady(session.pr)) {
     label = "ready";
   } else if (level === "respond") {
-    label = session.activity === "waiting_input" ? "waiting" : "needs input";
+    if (session.trustGates.trustGateHumanPlanApproval === "pending") {
+      label = "approve plan";
+    } else {
+      label = session.activity === "waiting_input" ? "waiting" : "needs input";
+    }
   } else if (level === "review") {
     label = session.pr?.reviewDecision === "changes_requested" ? "changes" : "review";
   } else if (level === "pending") {

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -209,6 +209,24 @@ describe("getAttentionLevel", () => {
       const session = createSession({ activity: "exited" });
       expect(getAttentionLevel(session)).toBe("respond");
     });
+
+    it("should return 'respond' when trustGateHumanPlanApproval is pending", () => {
+      const session = createSession({
+        status: "working",
+        activity: "idle",
+        trustGates: { trustGateHumanPlanApproval: "pending" },
+      });
+      expect(getAttentionLevel(session)).toBe("respond");
+    });
+
+    it("should not return 'respond' when trustGateHumanPlanApproval is satisfied", () => {
+      const session = createSession({
+        status: "working",
+        activity: "idle",
+        trustGates: { trustGateHumanPlanApproval: "satisfied" },
+      });
+      expect(getAttentionLevel(session)).toBe("working");
+    });
   });
 
   describe("review state", () => {

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -46,7 +46,7 @@ export { CI_STATUS, TERMINAL_STATUSES, TERMINAL_ACTIVITIES, NON_RESTORABLE_STATU
  * Attention zone priority level, ordered by human action urgency:
  *
  * 1. merge   — PR approved + CI green. One click to clear. Highest ROI.
- * 2. respond — Agent waiting for human input. Quick unblock, agent resumes.
+ * 2. respond — Human action required: agent blocked/crashed, or plan awaiting approval.
  * 3. review  — CI failed, changes requested, conflicts. Needs investigation.
  * 4. pending — Waiting on external (reviewer, CI). Nothing to do right now.
  * 5. working — Agents doing their thing. Don't interrupt.
@@ -221,7 +221,13 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
     return "merge";
   }
 
-  // ── Respond: agent is waiting for human input ─────────────────────
+  // ── Respond: human action is needed ──────────────────────────────
+  // Plan approval pending: planner wrote a plan that requires sign-off
+  // before the executor can be spawned. Surface here so it doesn't get
+  // buried in the Working column.
+  if (session.trustGates.trustGateHumanPlanApproval === "pending") {
+    return "respond";
+  }
   // Check status-based error conditions first — these are authoritative
   // and should not be masked by a stale activity value.
   if (


### PR DESCRIPTION
## Summary

Investigated the Web Attention Board's **Respond** column as requested in issue #7.

**Root cause of confusion**: Planner sessions with a pending `trustGateHumanPlanApproval` gate were silently falling into the *Working* column. The plan-approval UI only appeared in the SessionDetail drill-down view, making the two mechanisms look redundant when they're actually complementary layers.

**What changed**:
- `getAttentionLevel` now returns `"respond"` when `session.trustGates.trustGateHumanPlanApproval === "pending"`, so plan-approval-needed sessions are visible on the board without requiring a drill-down.
- Respond column caption updated from **"Human judgment needed"** (vague) to **"Your input is needed"** (clear, covers both cases).
- Mobile `SessionStateChip` now shows `"approve plan"` for plan-approval sessions in the Respond column, instead of the generic `"waiting"` / `"needs input"` labels.
- Two new unit tests for the new `getAttentionLevel` classification.

**How the two mechanisms relate (not redundant)**:
| Layer | Purpose |
|---|---|
| Respond column | Triage — tells you something needs your attention |
| Plan approval (SessionDetail) | Action — where you actually approve |

## Verification

- `pnpm --filter @composio/ao-web exec vitest run src/lib/__tests__/types.test.ts` → 41 tests pass (incl. 2 new)
- `pnpm --filter @composio/ao-web exec vitest run src/components/__tests__/Dashboard` → 27 tests pass
- `pnpm --filter @composio/ao-web exec vitest run src/components/__tests__/SessionDetail` → 16 tests pass
- No type errors in changed files (`types.ts`, `AttentionZone.tsx`)

## Trust / risk

- Scope: web UI classification logic only — no API, no core session state machine, no lifecycle changes.
- The `trustGateHumanPlanApproval` key is only written by the plan-approval flow, so the gate check is precise (no false positives for non-planner sessions).
- Sessions with `trustGateHumanPlanApproval: "satisfied"` or absent continue to route normally.

Closes #7