### PR TITLE
feat: push plan to tracker and poll LGTM approval signals

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -532,6 +532,9 @@ export interface Tracker {
 
   /** Optional: create a new issue */
   createIssue?(input: CreateIssueInput, project: ProjectConfig): Promise<Issue>;
+
+  /** Optional: list comments on an issue. Used for LGTM/reaction polling. */
+  getIssueComments?(identifier: string, project: ProjectConfig): Promise<IssueComment[]>;
 }
 
 export interface Issue {
@@ -566,6 +569,18 @@ export interface CreateIssueInput {
   labels?: string[];
   assignee?: string;
   priority?: number;
+}
+
+/** A comment on a tracker issue, returned by {@link Tracker.getIssueComments}. */
+export interface IssueComment {
+  /** Platform-specific comment id. */
+  id: string;
+  /** Author login / handle. */
+  author: string;
+  /** Raw comment body text. */
+  body: string;
+  /** ISO8601 creation timestamp. */
+  createdAt: string;
 }
 
 // =============================================================================

--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -10,6 +10,7 @@ import type {
   PluginModule,
   Tracker,
   Issue,
+  IssueComment,
   IssueFilters,
   IssueUpdate,
   CreateIssueInput,
@@ -349,6 +350,31 @@ function createGitHubTracker(): Tracker {
       const number = match[1];
 
       return this.getIssue(number, project);
+    },
+
+    async getIssueComments(identifier: string, project: ProjectConfig): Promise<IssueComment[]> {
+      const raw = await gh([
+        "issue",
+        "comment",
+        "list",
+        identifier,
+        "--repo",
+        project.repo,
+        "--json",
+        "id,author,body,createdAt",
+      ]);
+      const comments: Array<{
+        id: number;
+        author: { login: string };
+        body: string;
+        createdAt: string;
+      }> = JSON.parse(raw);
+      return comments.map((c) => ({
+        id: String(c.id),
+        author: c.author.login,
+        body: c.body,
+        createdAt: c.createdAt,
+      }));
     },
   };
 }

--- a/packages/plugins/tracker-github/test/index.test.ts
+++ b/packages/plugins/tracker-github/test/index.test.ts
@@ -464,4 +464,57 @@ describe("tracker-github plugin", () => {
       ).rejects.toThrow("Failed to parse issue URL");
     });
   });
+
+  // ---- getIssueComments --------------------------------------------------
+
+  describe("getIssueComments", () => {
+    const sampleComments = [
+      {
+        id: 111,
+        author: { login: "alice" },
+        body: "LGTM",
+        createdAt: "2026-04-06T10:00:00Z",
+      },
+      {
+        id: 222,
+        author: { login: "bob" },
+        body: "Please clarify step 2",
+        createdAt: "2026-04-06T11:00:00Z",
+      },
+    ];
+
+    it("returns mapped IssueComment array", async () => {
+      mockGh(sampleComments);
+      const comments = await tracker.getIssueComments!("42", project);
+      expect(comments).toEqual([
+        { id: "111", author: "alice", body: "LGTM", createdAt: "2026-04-06T10:00:00Z" },
+        { id: "222", author: "bob", body: "Please clarify step 2", createdAt: "2026-04-06T11:00:00Z" },
+      ]);
+    });
+
+    it("calls gh with correct arguments", async () => {
+      mockGh(sampleComments);
+      await tracker.getIssueComments!("42", project);
+      expect(ghMock).toHaveBeenCalledWith(
+        "gh",
+        expect.arrayContaining([
+          "issue", "comment", "list", "42",
+          "--repo", "acme/repo",
+          "--json", "id,author,body,createdAt",
+        ]),
+        expect.any(Object),
+      );
+    });
+
+    it("returns empty array when there are no comments", async () => {
+      mockGh([]);
+      const comments = await tracker.getIssueComments!("42", project);
+      expect(comments).toEqual([]);
+    });
+
+    it("propagates gh CLI errors", async () => {
+      mockGhError("comment list failed");
+      await expect(tracker.getIssueComments!("42", project)).rejects.toThrow("comment list failed");
+    });
+  });
 });

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -5,6 +5,11 @@ const {
   mockRegister,
   mockCreateSessionManager,
   mockRegistry,
+  mockProbePlanArtifact,
+  mockApprovePlanArtifact,
+  mockUpdateMetadata,
+  mockGetSessionsDir,
+  mockIsOrchestratorSession,
   tmuxPlugin,
   claudePlugin,
   opencodePlugin,
@@ -29,6 +34,11 @@ const {
     mockRegister,
     mockCreateSessionManager,
     mockRegistry,
+    mockProbePlanArtifact: vi.fn(),
+    mockApprovePlanArtifact: vi.fn(),
+    mockUpdateMetadata: vi.fn(),
+    mockGetSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+    mockIsOrchestratorSession: vi.fn().mockReturnValue(false),
     tmuxPlugin: { manifest: { name: "tmux" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     opencodePlugin: { manifest: { name: "opencode" } },
@@ -53,8 +63,22 @@ vi.mock("@composio/ao-core", () => ({
   getLeaves: vi.fn(),
   getSiblings: vi.fn(),
   formatPlanTree: vi.fn(),
+  probePlanArtifact: mockProbePlanArtifact,
+  approvePlanArtifactInWorkspace: mockApprovePlanArtifact,
+  updateMetadata: mockUpdateMetadata,
+  getSessionsDir: mockGetSessionsDir,
+  isOrchestratorSession: mockIsOrchestratorSession,
   DEFAULT_DECOMPOSER_CONFIG: {},
   TERMINAL_STATUSES: new Set(["merged", "killed"]) as ReadonlySet<string>,
+}));
+
+const { mockReadFileSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn().mockReturnValue("---\nstatus: pending_approval\n---\n\n## Plan body"),
+}));
+
+vi.mock("node:fs", () => ({
+  default: { readFileSync: mockReadFileSync },
+  readFileSync: mockReadFileSync,
 }));
 
 vi.mock("@composio/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
@@ -268,5 +292,237 @@ describe("pollBacklog", () => {
         workerRole: "executor",
       }),
     );
+  });
+});
+
+describe("pollBacklog — plan push and LGTM approval", () => {
+  const mockUpdateIssue = vi.fn();
+  const mockGetIssueComments = vi.fn();
+  const mockSpawn = vi.fn();
+  const mockListSessions = vi.fn();
+
+  const basePlannerSession = {
+    id: "test-project-1",
+    projectId: "test-project",
+    status: "working" as const,
+    activity: null,
+    branch: "feat/issue-42",
+    issueId: "42",
+    pr: null,
+    workspacePath: "/tmp/workspaces/test-project-1",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: { workerRole: "planner", planArtifactRelPath: ".ao/plan.md" },
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockRegister.mockClear();
+    mockCreateSessionManager.mockReset();
+    mockLoadConfig.mockReset();
+    mockUpdateIssue.mockClear();
+    mockGetIssueComments.mockClear();
+    mockSpawn.mockClear();
+    mockListSessions.mockClear();
+    mockProbePlanArtifact.mockClear();
+    mockApprovePlanArtifact.mockClear();
+    mockUpdateMetadata.mockClear();
+    mockIsOrchestratorSession.mockReturnValue(false);
+
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/agent-orchestrator.yaml",
+      port: 3000,
+      readyThresholdMs: 300_000,
+      defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+      projects: {
+        "test-project": {
+          path: "/tmp/test-project",
+          tracker: { plugin: "github" },
+        },
+      },
+      notifiers: {},
+      notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+      reactions: {},
+    });
+
+    mockListSessions.mockResolvedValue([]);
+
+    mockCreateSessionManager.mockReturnValue({
+      spawn: mockSpawn,
+      list: mockListSessions,
+    });
+
+    mockRegistry.get.mockImplementation((slot: string) => {
+      if (slot === "tracker") {
+        return {
+          name: "github",
+          listIssues: vi.fn().mockResolvedValue([]),
+          updateIssue: mockUpdateIssue,
+          getIssueComments: mockGetIssueComments,
+        };
+      }
+      return null;
+    });
+
+    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
+    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+  });
+
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
+    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+  });
+
+  it("posts plan as tracker comment when plan is pending_approval", async () => {
+    mockListSessions.mockResolvedValue([basePlannerSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "pending_approval",
+    });
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockUpdateMetadata).toHaveBeenCalledWith(
+      "/tmp/sessions",
+      "test-project-1",
+      { planPostedToTracker: "true" },
+    );
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      "42",
+      expect.objectContaining({
+        labels: ["agent:plan-pending"],
+        comment: expect.stringContaining("awaiting approval"),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not post plan again when planPostedToTracker is already true", async () => {
+    const alreadyPostedSession = {
+      ...basePlannerSession,
+      metadata: { ...basePlannerSession.metadata, planPostedToTracker: "true" },
+    };
+    mockListSessions.mockResolvedValue([alreadyPostedSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "pending_approval",
+    });
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockUpdateMetadata).not.toHaveBeenCalled();
+  });
+
+  it("approves plan when LGTM is found in a comment", async () => {
+    const postedSession = {
+      ...basePlannerSession,
+      metadata: { ...basePlannerSession.metadata, planPostedToTracker: "true" },
+    };
+    mockListSessions.mockResolvedValue([postedSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "pending_approval",
+    });
+    mockGetIssueComments.mockResolvedValue([
+      { id: "1", author: "alice", body: "LGTM", createdAt: "2026-04-06T12:00:00Z" },
+    ]);
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockApprovePlanArtifact).toHaveBeenCalledWith(
+      "/tmp/workspaces/test-project-1",
+      ".ao/plan.md",
+      { approvedBy: "alice" },
+    );
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      "42",
+      expect.objectContaining({
+        labels: ["agent:plan-approved"],
+        removeLabels: ["agent:plan-pending"],
+        comment: expect.stringContaining("alice"),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("approves plan when 👍 emoji is found in a comment", async () => {
+    const postedSession = {
+      ...basePlannerSession,
+      metadata: { ...basePlannerSession.metadata, planPostedToTracker: "true" },
+    };
+    mockListSessions.mockResolvedValue([postedSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "pending_approval",
+    });
+    mockGetIssueComments.mockResolvedValue([
+      { id: "2", author: "bob", body: "👍 looks good", createdAt: "2026-04-06T13:00:00Z" },
+    ]);
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockApprovePlanArtifact).toHaveBeenCalledWith(
+      "/tmp/workspaces/test-project-1",
+      ".ao/plan.md",
+      { approvedBy: "bob" },
+    );
+  });
+
+  it("skips LGTM polling when plan is already approved", async () => {
+    const postedSession = {
+      ...basePlannerSession,
+      metadata: { ...basePlannerSession.metadata, planPostedToTracker: "true" },
+    };
+    mockListSessions.mockResolvedValue([postedSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "approved",
+    });
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockGetIssueComments).not.toHaveBeenCalled();
+    expect(mockApprovePlanArtifact).not.toHaveBeenCalled();
+  });
+
+  it("skips plan operations when tracker has no getIssueComments", async () => {
+    const postedSession = {
+      ...basePlannerSession,
+      metadata: { ...basePlannerSession.metadata, planPostedToTracker: "true" },
+    };
+    mockListSessions.mockResolvedValue([postedSession]);
+    mockProbePlanArtifact.mockReturnValue({
+      path: "/tmp/workspaces/test-project-1/.ao/plan.md",
+      found: true,
+      status: "pending_approval",
+    });
+    mockRegistry.get.mockImplementation((slot: string) => {
+      if (slot === "tracker") {
+        return {
+          name: "github",
+          listIssues: vi.fn().mockResolvedValue([]),
+          updateIssue: mockUpdateIssue,
+          // no getIssueComments
+        };
+      }
+      return null;
+    });
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockApprovePlanArtifact).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -19,6 +19,10 @@ import {
   getLeaves,
   getSiblings,
   formatPlanTree,
+  probePlanArtifact,
+  approvePlanArtifactInWorkspace,
+  updateMetadata,
+  getSessionsDir,
   type OrchestratorConfig,
   type PluginRegistry,
   type OpenCodeSessionManager,
@@ -34,6 +38,7 @@ import {
   isOrchestratorSession,
   TERMINAL_STATUSES,
 } from "@composio/ao-core";
+import { readFileSync } from "node:fs";
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
@@ -221,6 +226,112 @@ async function relabelReopenedIssues(
   }
 }
 
+const PLAN_PENDING_LABEL = "agent:plan-pending";
+const PLAN_APPROVED_LABEL = "agent:plan-approved";
+
+/**
+ * If a planner session has a `.ao/plan.md` with `status: pending_approval`
+ * and has not already posted to the tracker, post the plan content as an
+ * issue comment and apply the `agent:plan-pending` label.
+ * Idempotent: sets `planPostedToTracker=true` in session metadata before posting.
+ */
+async function pushPlanToTracker(
+  session: Session,
+  tracker: Tracker,
+  project: ProjectConfig,
+  sessionsDir: string,
+): Promise<void> {
+  if (!session.workspacePath || !session.issueId || !tracker.updateIssue) return;
+  if (session.metadata["planPostedToTracker"] === "true") return;
+
+  const probe = probePlanArtifact(session.workspacePath);
+  if (!probe.found || probe.status === "approved") return;
+  if (probe.status !== "pending_approval") return;
+
+  let planContent: string;
+  try {
+    planContent = readFileSync(probe.path, "utf-8");
+  } catch {
+    return;
+  }
+
+  // Mark as posted before the API call to avoid re-posting on crash recovery.
+  updateMetadata(sessionsDir, session.id, { planPostedToTracker: "true" });
+
+  await tracker.updateIssue(
+    session.issueId,
+    {
+      comment: `## Plan (awaiting approval)\n\n${planContent}\n\n---\n_Reply **LGTM** or 👍 to approve this plan and allow the executor session to start._`,
+      labels: [PLAN_PENDING_LABEL],
+    },
+    project,
+  );
+  console.log(`[backlog] Posted plan for session ${session.id} (issue ${session.issueId})`);
+}
+
+/**
+ * Poll issue comments for "LGTM" text or 👍 emoji. When found, approve the
+ * plan artifact and swap the tracker label from `agent:plan-pending` to
+ * `agent:plan-approved`.
+ */
+async function pollPlanApprovalSignals(
+  session: Session,
+  tracker: Tracker,
+  project: ProjectConfig,
+): Promise<void> {
+  if (
+    !session.workspacePath ||
+    !session.issueId ||
+    !tracker.updateIssue ||
+    !tracker.getIssueComments
+  )
+    return;
+
+  // Only poll after the plan has been posted.
+  if (session.metadata["planPostedToTracker"] !== "true") return;
+
+  // Skip if already approved.
+  const probe = probePlanArtifact(session.workspacePath);
+  if (!probe.found || probe.status === "approved") return;
+
+  let comments: Awaited<ReturnType<NonNullable<typeof tracker.getIssueComments>>>;
+  try {
+    comments = await tracker.getIssueComments(session.issueId, project);
+  } catch {
+    return;
+  }
+
+  const approvalComment = comments.find((c) => {
+    const body = c.body.trim();
+    return body.toLowerCase().includes("lgtm") || body.includes("👍");
+  });
+  if (!approvalComment) return;
+
+  try {
+    approvePlanArtifactInWorkspace(
+      session.workspacePath,
+      session.metadata["planArtifactRelPath"],
+      { approvedBy: approvalComment.author },
+    );
+  } catch (err) {
+    console.error(`[backlog] Failed to approve plan for session ${session.id}:`, err);
+    return;
+  }
+
+  await tracker.updateIssue(
+    session.issueId,
+    {
+      comment: `Plan approved by @${approvalComment.author} via LGTM signal. Executor session will be spawned when CI gates are satisfied.`,
+      labels: [PLAN_APPROVED_LABEL],
+      removeLabels: [PLAN_PENDING_LABEL],
+    },
+    project,
+  );
+  console.log(
+    `[backlog] Plan approved for session ${session.id} by ${approvalComment.author} (issue ${session.issueId})`,
+  );
+}
+
 export async function pollBacklog(): Promise<void> {
   try {
     const { config, registry, sessionManager } = await getServices();
@@ -232,6 +343,22 @@ export async function pollBacklog(): Promise<void> {
 
     // Detect reopened issues: open state + agent:done label → relabel as agent:backlog
     await relabelReopenedIssues(config, registry);
+
+    // Push pending plans to tracker and poll for LGTM approval signals.
+    for (const session of allSessions) {
+      if (session.metadata["workerRole"] !== "planner") continue;
+      const project = config.projects[session.projectId];
+      if (!project?.tracker) continue;
+      const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
+      if (!tracker) continue;
+      const sessionsDir = getSessionsDir(config.configPath, project.path);
+      try {
+        await pushPlanToTracker(session, tracker, project, sessionsDir);
+        await pollPlanApprovalSignals(session, tracker, project);
+      } catch (err) {
+        console.error(`[backlog] Plan polling failed for session ${session.id}:`, err);
+      }
+    }
 
     const workerSessions = allSessions.filter(
       (session) => !isOrchestratorSession(session) && !TERMINAL_STATUSES.has(session.status),


### PR DESCRIPTION
## Summary

Implements the three requirements from issue #12:

- **Push plan to tracker**: When a planner session writes `.ao/plan.md` with `status: pending_approval`, the backlog polling loop now detects it and posts the plan content as a comment on the tracker issue, applying the standardized `agent:plan-pending` label.
- **Standardized label**: Introduces `agent:plan-pending` (waiting for human approval) and `agent:plan-approved` (LGTM received) as the canonical labels for plan approval state.
- **LGTM / 👍 approval**: A new polling function scans issue comments for the text "lgtm" (case-insensitive) or the 👍 emoji. When found, it calls `approvePlanArtifactInWorkspace` to write `status: approved` to the plan frontmatter and swaps the label to `agent:plan-approved`.

### Changed files

| File | Change |
|------|--------|
| `packages/core/src/types.ts` | Add `IssueComment` interface; add optional `getIssueComments?` method to `Tracker` |
| `packages/plugins/tracker-github/src/index.ts` | Implement `getIssueComments` via `gh issue comment list --json` |
| `packages/web/src/lib/services.ts` | Add `pushPlanToTracker`, `pollPlanApprovalSignals`, integrate into `pollBacklog` |

## Verification

```
pnpm --filter @composio/ao-plugin-tracker-github test   # 46/46 pass
pnpm --filter @composio/ao-core test                    # 606/606 pass
pnpm --filter @composio/ao-web test                     # 535/535 pass
pnpm typecheck                                          # 0 errors
pnpm lint                                               # 0 errors
```

## Trust / risk

- **Idempotency**: `pushPlanToTracker` writes `planPostedToTracker: true` to session metadata *before* the `gh issue comment` API call to avoid duplicate posts on crash-recovery.
- **Scope**: Changes are limited to the plan-phase planner sessions (`workerRole === "planner"`). The existing decompose-pending label flow is unchanged.
- **Out of scope**: GitHub Reactions API (emoji reactions on comments — comment text scanning covers the MVP). Linear/GitLab `getIssueComments` not implemented (method is optional on the interface).

Closes #12