### PR TITLE
feat: better empty state for Kanban board with tracker-aware create issue link

### DIFF
--- a/packages/web/src/app/page.test.tsx
+++ b/packages/web/src/app/page.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const dashboardSpy = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/Dashboard", () => ({
+  Dashboard: (props: Record<string, unknown>) => {
+    dashboardSpy(props);
+    return <div data-testid="dashboard" />;
+  },
+}));
+
+vi.mock("@/lib/dashboard-page-data", () => ({
+  getDashboardPageData: vi.fn().mockResolvedValue({
+    sessions: [],
+    globalPause: null,
+    orchestrators: [],
+    projectName: "Test",
+    projects: [],
+    selectedProjectId: "myproject",
+    newIssueUrl: "https://github.com/owner/repo/issues/new",
+  }),
+  getDashboardProjectName: vi.fn().mockReturnValue("Test"),
+  resolveDashboardProjectFilter: vi.fn().mockReturnValue("myproject"),
+}));
+
+describe("Home page", () => {
+  it("passes newIssueUrl from pageData to Dashboard", async () => {
+    const { default: Home } = await import("./page");
+    const element = await Home({ searchParams: Promise.resolve({}) });
+    render(element);
+
+    expect(screen.getByTestId("dashboard")).toBeInTheDocument();
+    expect(dashboardSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ newIssueUrl: "https://github.com/owner/repo/issues/new" }),
+    );
+  });
+});

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -30,6 +30,7 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
       projects={pageData.projects}
       initialGlobalPause={pageData.globalPause}
       orchestrators={pageData.orchestrators}
+      newIssueUrl={pageData.newIssueUrl}
     />
   );
 }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -33,6 +33,7 @@ interface DashboardProps {
   projects?: ProjectInfo[];
   initialGlobalPause?: GlobalPauseState | null;
   orchestrators?: DashboardOrchestratorLink[];
+  newIssueUrl?: string;
 }
 
 const KANBAN_LEVELS = ["working", "pending", "review", "respond", "merge"] as const;
@@ -70,6 +71,7 @@ function DashboardInner({
   projects = [],
   initialGlobalPause = null,
   orchestrators,
+  newIssueUrl,
 }: DashboardProps) {
   const orchestratorLinks = orchestrators ?? EMPTY_ORCHESTRATORS;
   const { sessions, globalPause, connectionStatus } = useSessionEvents(
@@ -759,7 +761,7 @@ function DashboardInner({
           </div>
         )}
 
-        {!allProjectsView && !hasAnySessions && <EmptyState />}
+        {!allProjectsView && !hasAnySessions && <EmptyState newIssueUrl={newIssueUrl} />}
 
       </div>
     </div>

--- a/packages/web/src/components/Skeleton.tsx
+++ b/packages/web/src/components/Skeleton.tsx
@@ -2,10 +2,12 @@
 
 interface EmptyStateProps {
   message?: string;
+  newIssueUrl?: string;
 }
 
 export function EmptyState({
   message,
+  newIssueUrl,
 }: EmptyStateProps) {
   const isDefault = !message;
   return (
@@ -24,10 +26,24 @@ export function EmptyState({
       <p className="text-[13px] text-[var(--color-text-muted)]">
         {isDefault ? (
           <>
-            No sessions running. Start one with{" "}
-            <code className="font-[var(--font-mono)] text-[var(--color-text-secondary)]">
-              ao start
-            </code>
+            No issues assigned yet.{" "}
+            {newIssueUrl ? (
+              <a
+                href={newIssueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-text-secondary)] underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+              >
+                Create a new issue
+              </a>
+            ) : (
+              <>
+                Start one with{" "}
+                <code className="font-[var(--font-mono)] text-[var(--color-text-secondary)]">
+                  ao start
+                </code>
+              </>
+            )}
           </>
         ) : (
           message

--- a/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 describe("Dashboard empty state", () => {
   it("shows empty state when there are no sessions (single-project view)", () => {
     render(<Dashboard initialSessions={[]} />);
-    expect(screen.getByText(/No sessions running/i)).toBeInTheDocument();
+    expect(screen.getByText(/No issues assigned yet/i)).toBeInTheDocument();
   });
 
   it("does not show empty state when sessions exist", () => {
@@ -56,6 +56,20 @@ describe("Dashboard empty state", () => {
         ]}
       />,
     );
-    expect(queryByText(/No sessions running/i)).not.toBeInTheDocument();
+    expect(queryByText(/No issues assigned yet/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a create issue link when newIssueUrl is provided", () => {
+    render(<Dashboard initialSessions={[]} newIssueUrl="https://github.com/test/repo/issues/new" />);
+    const link = screen.getByRole("link", { name: /create a new issue/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "https://github.com/test/repo/issues/new");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("falls back to ao start instruction when newIssueUrl is not provided", () => {
+    render(<Dashboard initialSessions={[]} />);
+    expect(screen.getByText(/ao start/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /create a new issue/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
@@ -6,6 +6,10 @@ const { getAllProjectsMock, getPrimaryProjectIdMock, getProjectNameMock } = vi.h
   getProjectNameMock: vi.fn(),
 }));
 
+const { getServicesMock } = vi.hoisted(() => ({
+  getServicesMock: vi.fn(),
+}));
+
 vi.mock("@/lib/project-name", () => ({
   getAllProjects: getAllProjectsMock,
   getPrimaryProjectId: getPrimaryProjectIdMock,
@@ -13,11 +17,38 @@ vi.mock("@/lib/project-name", () => ({
 }));
 
 vi.mock("@/lib/services", () => ({
-  getServices: vi.fn(),
+  getServices: getServicesMock,
   getSCM: vi.fn(),
 }));
 
-import { resolveDashboardProjectFilter } from "@/lib/dashboard-page-data";
+vi.mock("@/lib/serialize", () => ({
+  sessionToDashboard: vi.fn((s: unknown) => s),
+  resolveProject: vi.fn(),
+  enrichSessionPR: vi.fn(),
+  enrichSessionsMetadata: vi.fn().mockResolvedValue(undefined),
+  listDashboardOrchestrators: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  prCache: { get: vi.fn() },
+  prCacheKey: vi.fn(),
+}));
+
+vi.mock("@/lib/global-pause", () => ({
+  resolveGlobalPause: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/project-utils", () => ({
+  filterProjectSessions: vi.fn().mockReturnValue([]),
+  filterWorkerSessions: vi.fn().mockReturnValue([]),
+}));
+
+import {
+  resolveDashboardProjectFilter,
+  resolveNewIssueUrl,
+  getDashboardPageData,
+} from "@/lib/dashboard-page-data";
+import type { ProjectConfig } from "@composio/ao-core";
 
 describe("resolveDashboardProjectFilter", () => {
   beforeEach(() => {
@@ -44,5 +75,112 @@ describe("resolveDashboardProjectFilter", () => {
 
   it("falls back to primary project when no project is given", () => {
     expect(resolveDashboardProjectFilter(undefined)).toBe("mono");
+  });
+});
+
+function makeProjectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    name: "Test Project",
+    repo: "owner/repo",
+    path: "/tmp/repo",
+    ...overrides,
+  } as unknown as ProjectConfig;
+}
+
+describe("resolveNewIssueUrl", () => {
+  it("returns undefined when tracker is not configured", () => {
+    expect(resolveNewIssueUrl(makeProjectConfig())).toBeUndefined();
+  });
+
+  it("returns a GitHub new-issue URL for the github tracker", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "github" } });
+    expect(resolveNewIssueUrl(project)).toBe("https://github.com/owner/repo/issues/new");
+  });
+
+  it("handles tracker-github plugin prefix", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "tracker-github" } });
+    expect(resolveNewIssueUrl(project)).toBe("https://github.com/owner/repo/issues/new");
+  });
+
+  it("returns a Linear new-issue URL when workspaceSlug is configured", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "linear", workspaceSlug: "myteam" } });
+    expect(resolveNewIssueUrl(project)).toBe("https://linear.app/myteam/issues/new");
+  });
+
+  it("returns undefined for linear tracker without workspaceSlug", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "linear" } });
+    expect(resolveNewIssueUrl(project)).toBeUndefined();
+  });
+
+  it("returns a GitLab new-issue URL for the gitlab tracker", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "gitlab" } });
+    expect(resolveNewIssueUrl(project)).toBe("https://gitlab.com/owner/repo/-/issues/new");
+  });
+
+  it("returns undefined for unknown tracker plugins", () => {
+    const project = makeProjectConfig({ tracker: { plugin: "jira" } });
+    expect(resolveNewIssueUrl(project)).toBeUndefined();
+  });
+});
+
+describe("getDashboardPageData — newIssueUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllProjectsMock.mockReturnValue([{ id: "myproject", name: "My Project" }]);
+    getPrimaryProjectIdMock.mockReturnValue("myproject");
+    getProjectNameMock.mockReturnValue("My Project");
+  });
+
+  it("sets newIssueUrl from project tracker config", async () => {
+    getServicesMock.mockResolvedValue({
+      config: {
+        projects: {
+          myproject: {
+            name: "My Project",
+            repo: "owner/repo",
+            path: "/tmp/repo",
+            tracker: { plugin: "github" },
+          },
+        },
+      },
+      registry: {},
+      sessionManager: { list: vi.fn().mockResolvedValue([]) },
+      lifecycleManager: {},
+    });
+
+    const data = await getDashboardPageData("myproject");
+    expect(data.newIssueUrl).toBe("https://github.com/owner/repo/issues/new");
+  });
+
+  it("leaves newIssueUrl undefined when project has no tracker", async () => {
+    getServicesMock.mockResolvedValue({
+      config: {
+        projects: {
+          myproject: {
+            name: "My Project",
+            repo: "owner/repo",
+            path: "/tmp/repo",
+          },
+        },
+      },
+      registry: {},
+      sessionManager: { list: vi.fn().mockResolvedValue([]) },
+      lifecycleManager: {},
+    });
+
+    const data = await getDashboardPageData("myproject");
+    expect(data.newIssueUrl).toBeUndefined();
+  });
+
+  it("leaves newIssueUrl undefined for all-projects view", async () => {
+    getServicesMock.mockResolvedValue({
+      config: { projects: {} },
+      registry: {},
+      sessionManager: { list: vi.fn().mockResolvedValue([]) },
+      lifecycleManager: {},
+    });
+
+    const data = await getDashboardPageData("all");
+    expect(data.newIssueUrl).toBeUndefined();
   });
 });

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -24,7 +24,7 @@ interface DashboardPageData {
   newIssueUrl?: string;
 }
 
-function resolveNewIssueUrl(project: ProjectConfig): string | undefined {
+export function resolveNewIssueUrl(project: ProjectConfig): string | undefined {
   const plugin = project.tracker?.plugin;
   if (!plugin) return undefined;
 

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -12,6 +12,7 @@ import { prCache, prCacheKey } from "@/lib/cache";
 import { getPrimaryProjectId, getProjectName, getAllProjects, type ProjectInfo } from "@/lib/project-name";
 import { filterProjectSessions, filterWorkerSessions } from "@/lib/project-utils";
 import { resolveGlobalPause, type GlobalPauseState } from "@/lib/global-pause";
+import type { ProjectConfig } from "@composio/ao-core";
 
 interface DashboardPageData {
   sessions: DashboardSession[];
@@ -20,6 +21,30 @@ interface DashboardPageData {
   projectName: string;
   projects: ProjectInfo[];
   selectedProjectId?: string;
+  newIssueUrl?: string;
+}
+
+function resolveNewIssueUrl(project: ProjectConfig): string | undefined {
+  const plugin = project.tracker?.plugin;
+  if (!plugin) return undefined;
+
+  const normalizedPlugin = plugin.replace(/^tracker-/, "");
+
+  if (normalizedPlugin === "github") {
+    return `https://github.com/${project.repo}/issues/new`;
+  }
+
+  if (normalizedPlugin === "linear") {
+    const slug = project.tracker?.["workspaceSlug"] as string | undefined;
+    if (slug) return `https://linear.app/${slug}/issues/new`;
+    return undefined;
+  }
+
+  if (normalizedPlugin === "gitlab") {
+    return `https://gitlab.com/${project.repo}/-/issues/new`;
+  }
+
+  return undefined;
 }
 
 export const getDashboardProjectName = cache(function getDashboardProjectName(
@@ -59,6 +84,13 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     const allSessions = await sessionManager.list();
 
     pageData.globalPause = resolveGlobalPause(allSessions);
+
+    if (pageData.selectedProjectId) {
+      const projectConfig = config.projects[pageData.selectedProjectId];
+      if (projectConfig) {
+        pageData.newIssueUrl = resolveNewIssueUrl(projectConfig);
+      }
+    }
 
     const visibleSessions = filterProjectSessions(allSessions, projectFilter, config.projects);
     pageData.orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);


### PR DESCRIPTION
## Summary

- Replaces the inaccurate "No sessions running. Start one with `ao start`" copy with "No issues assigned yet." — more accurate since ao itself is a running session
- Adds a tracker-aware "Create a new issue" link when the project has a configured tracker:
  - **GitHub**: `https://github.com/{owner/repo}/issues/new`
  - **Linear**: `https://linear.app/{workspaceSlug}/issues/new` (requires `workspaceSlug` in tracker config)
  - **GitLab**: `https://gitlab.com/{owner/repo}/-/issues/new`
- Falls back to the original `ao start` instruction when no tracker URL can be derived

## Changes

- `Skeleton.tsx` — `EmptyState` accepts `newIssueUrl?: string`; renders a link when present
- `Dashboard.tsx` — threads `newIssueUrl` prop through to `EmptyState`
- `dashboard-page-data.ts` — `resolveNewIssueUrl()` derives the URL from `ProjectConfig` server-side; added `newIssueUrl` to `DashboardPageData`
- `app/page.tsx` — passes `pageData.newIssueUrl` to `<Dashboard>`
- `Dashboard.emptyState.test.tsx` — updated existing tests, added 2 new tests for link/fallback behavior

## Test plan

- [x] `Dashboard.emptyState.test.tsx` — 4 tests pass
- [x] No new TypeScript errors introduced (pre-existing unbuilt-plugin errors in worktree are unrelated)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)